### PR TITLE
Added chance to set start and end time of the experiment

### DIFF
--- a/MultiJoint_Setup_Analysis_Script/Experiment/Experiment.m
+++ b/MultiJoint_Setup_Analysis_Script/Experiment/Experiment.m
@@ -1,34 +1,123 @@
 classdef Experiment < handle
     % Loads experimental data
-
     properties (Access = public)
-        Data
+        Data__
+        StartTime % Time in seconds, [] if not set
+        EndTime   % Time in seconds, [] or 'end' if not set
+        StartIndex__ % Index, calculated based on StartTime
+        EndIndex__   % Index, calculated based on EndTime
     end
-    
+
+    properties (Access = private, Dependent)
+        ExperimentDuration
+        MeanSampleTime
+    end
+
     methods
+        function duration = get.ExperimentDuration(obj)
+            if ~isempty(obj.Data__) && isfield(obj.Data__, 'joints_state') && isfield(obj.Data__.joints_state, 'positions') && isfield(obj.Data__.joints_state.positions, 'timestamps')
+                duration = obj.Data__.joints_state.positions.timestamps(1, :);
+            else
+                duration = [];
+            end
+        end
+
+        function ts = get.MeanSampleTime(obj)
+            if length(obj.ExperimentDuration) > 1
+                ts = mean(diff(obj.ExperimentDuration));
+            else
+                ts = NaN;
+            end
+        end
+
         function obj = LoadData(obj, dataPath)
-            % Loads the data from the file            
             loadedData = load(dataPath);
             fn = fieldnames(loadedData);
-            obj.Data = loadedData.(fn{1});
+            if ~isempty(fn)
+                obj.Data__ = loadedData.(fn{1});
+                obj.updateIndices();
+            else
+                error('Loaded data file is empty.');
+            end
         end
-        
+
+        function set.StartTime(obj, value)
+            if isnumeric(value) && isscalar(value) && value >= 0
+                obj.StartTime = value;
+                obj.updateIndices();
+            elseif isempty(value)
+                warning('StartTime is empty, setting it to 0.');
+                obj.StartTime = [];
+                obj.updateIndices();
+            else
+                warning('StartTime must be a non-negative scalar numeric value or empty.');
+                obj.StartTime = [];
+                obj.updateIndices();
+            end
+        end
+
+        function set.EndTime(obj, value)
+            if isnumeric(value) && isscalar(value) && value >= 0
+                obj.EndTime = value;
+                obj.updateIndices();
+            elseif ischar(value) && strcmp(value, 'end')
+                obj.EndTime = 'end';
+                obj.updateIndices();
+            elseif isempty(value)
+                warning('EndTime is empty. Loading the whole experiment.');
+                obj.EndTime = [];
+                obj.updateIndices();
+            else
+                warning('EndTime must be a non-negative scalar numeric value, "end", or empty.');
+                obj.EndTime = [];
+                obj.updateIndices();
+            end
+        end
+
+        function updateIndices(obj)
+            if isempty(obj.Data__) || isempty(obj.ExperimentDuration) || isnan(obj.MeanSampleTime)
+                obj.StartIndex__ = [];
+                obj.EndIndex__ = [];
+                return;
+            end
+
+            if isempty(obj.StartTime)
+                obj.StartIndex__ = 1;
+            else
+                calculatedStart = round(obj.StartTime / obj.MeanSampleTime) + 1;
+                obj.StartIndex__ = max(1, calculatedStart);
+            end
+
+            dataLength = length(obj.ExperimentDuration);
+            
+            if isempty(obj.EndTime) || (ischar(obj.EndTime) && strcmp(obj.EndTime, 'end'))
+                obj.EndIndex__ = dataLength;
+            elseif isnumeric(obj.EndTime)
+                calculatedEnd = round(obj.EndTime / obj.MeanSampleTime) + 1;
+                obj.EndIndex__ = min(dataLength, max(obj.StartIndex__, calculatedEnd));
+            else
+                obj.EndIndex__ = dataLength; % Default to end on invalid EndTime
+            end
+        end
+
         function descList = GetDescriptionList(obj)
-            % Returns the joint description list.
-            descList = obj.Data.description_list;
+            if ~isempty(obj.Data__) && isfield(obj.Data__, 'description_list')
+                descList = obj.Data__.description_list;
+            else
+                descList = {};
+            end
         end
-        
+
         function nJoints = GetNumberOfJoints(obj)
-            % Returns the number of joints.            
             descList = obj.GetDescriptionList();
             nJoints = numel(descList);
         end
-        
+
         function setReductionRatios(obj, varargin)
             % Sets gearbox reduction ratios for each joint.
             % If fewer ratios are provided than joints, missing values default to 1.
             % if more are provided, the extras are discarded.
-            
+
             nJoints = obj.GetNumberOfJoints();
             ratios = cell2mat(varargin);
             if isempty(ratios)
@@ -42,40 +131,49 @@ classdef Experiment < handle
                 warning('Too many ratios: extra values will be dropped.');
                 ratios = ratios(1:nJoints);
             end
-
-            obj.Data.reduction_ratios = ratios;
-        end
-        
-        function rawData = GetRawData(obj)
-            % Returns rearranged raw encoder data.
-          
-            nJoints = obj.GetNumberOfJoints();
-            encodersNum = 2 * nJoints;
-
-            rawArray = obj.Data.raw_data_values.eoprot_tag_mc_joint_status_addinfo_multienc.data;
-            dataLen = size(rawArray, 3);
-            disp(dataLen)
-            rawData = zeros(encodersNum, dataLen);
-
-            for i = 1:nJoints
-                % Primary encoder: row (3*i-2), Secondary: row (3*i-1)
-                rawData(i*2-1:i*2, :) = rawArray((3*i-2):(3*i-1), :);
+            if ~isempty(obj.Data__)
+                obj.Data__.reduction_ratios = ratios;
+            else
+                warning('Data not loaded. Cannot set reduction ratios.');
             end
         end
-        
-        function [diagData, nSamples] = GetDiagnosticData(obj)
-            % Retrieves diagnostic data and sample count.
 
-            diagArray = obj.Data.raw_data_values.eoprot_tag_mc_joint_status_addinfo_multienc.data;
-            % For diagnostic data, every third row is used.
-            diagData = diagArray(3:3:size(diagArray,1), :);
+        function rawData = GetRawData(obj)
+            if isempty(obj.Data__) || ~isfield(obj.Data__.raw_data_values, 'eoprot_tag_mc_joint_status_addinfo_multienc') || isempty(obj.StartIndex__) || isempty(obj.EndIndex__)
+                rawData = [];
+                return;
+            end
+            rawArray = obj.Data__.raw_data_values.eoprot_tag_mc_joint_status_addinfo_multienc.data;
+            nJoints = obj.GetNumberOfJoints();
+            encodersNum = 2 * nJoints;
+            rawData = zeros(encodersNum, obj.EndIndex__ - obj.StartIndex__ + 1);
+            for i = 1:nJoints
+                indices = obj.StartIndex__:obj.EndIndex__;
+                rawData(i*2-1:i*2, :) = rawArray((3*i-2):(3*i-1), indices);
+            end
+        end
+
+        function [diagData, nSamples] = GetDiagnosticData(obj)
+            if isempty(obj.Data__) || ~isfield(obj.Data__.raw_data_values, 'eoprot_tag_mc_joint_status_addinfo_multienc') || isempty(obj.StartIndex__) || isempty(obj.EndIndex__)
+                diagData = [];
+                nSamples = 0;
+                return;
+            end
+            diagArray = obj.Data__.raw_data_values.eoprot_tag_mc_joint_status_addinfo_multienc.data;
+            diagData = diagArray(3:3:size(diagArray,1), obj.StartIndex__:obj.EndIndex__);
             nSamples = size(diagData, 2);
         end
-        
+
         function timestamps = GetTimestamps(obj)
-            % Retrieves normalized timestamps.           
-            timestamps = obj.Data.joints_state.positions.timestamps(1, :);
-            timestamps = timestamps - timestamps(1);
+            if isempty(obj.Data__) || ~isfield(obj.Data__, 'joints_state') || ~isfield(obj.Data__.joints_state, 'positions') || ~isfield(obj.Data__.joints_state.positions, 'timestamps') || isempty(obj.StartIndex__) || isempty(obj.EndIndex__)
+                timestamps = [];
+                return;
+            end
+            allTimestamps = obj.Data__.joints_state.positions.timestamps(1, :);
+            timestamps = allTimestamps(obj.StartIndex__:obj.EndIndex__);
+            if ~isempty(timestamps)
+                timestamps = timestamps - timestamps(1);
+            end
         end
     end
 end

--- a/MultiJoint_Setup_Analysis_Script/Joint/Joint.m
+++ b/MultiJoint_Setup_Analysis_Script/Joint/Joint.m
@@ -14,11 +14,11 @@ classdef Joint < handle
         function obj = Joint(exp)
             % Joint constructor extracts joint data from an Experiment instance.            
             obj.DescriptionList = exp.GetDescriptionList();
-            obj.Accelerations = obj.GetJointAccelerations(exp.Data);
-            obj.Velocities = obj.GetJointVelocities(exp.Data);
-            obj.Positions = obj.GetJointPositions(exp.Data);
-            if isfield(exp.Data, 'reduction_ratios')
-                obj.ReductionRatios = exp.Data.reduction_ratios;
+            obj.Accelerations = obj.GetJointAccelerations(exp.Data__);
+            obj.Velocities = obj.GetJointVelocities(exp.Data__);
+            obj.Positions = obj.GetJointPositions(exp.Data__);
+            if isfield(exp.Data__, 'reduction_ratios')
+                obj.ReductionRatios = exp.Data__.reduction_ratios;
             else
                 obj.ReductionRatios = ones(1, numel(obj.DescriptionList));
             end

--- a/MultiJoint_Setup_Analysis_Script/main.m
+++ b/MultiJoint_Setup_Analysis_Script/main.m
@@ -13,27 +13,28 @@ addpath('Experiment/UtilityScripts');
 addpath('Data');
 % ----- End of locate resources ----- %
 %% Load data:
-my_experiment_A = Experiment(); % Experiment 1 
-my_experiment_A.LoadData('4.3_normal_2.mat');
-my_experiment_B = Experiment(); % Experiment 2
-my_experiment_B.LoadData('torso_pitch_mj1_aksim_amo_position_1742988005.992320.mat');
+my_experiment_A = Experiment(); % Experiment 1
+
+my_experiment_A.LoadData('data.mat'); % Load the data
+
+my_experiment_A.StartTime = 40; % If not specified, StartTime = 0
+my_experiment_A.EndTime = 500; % If not specified, EndTime = end of the experiment
+
+disp(['You are analyzing a ', num2str(my_experiment_A.EndTime - my_experiment_A.StartTime), ' [secs] long experiment.'])
+
+% my_experiment_B = Experiment(); % Experiment 2
+
 %% Create encoder objects:
 my_aksim_encoder_A = AksimEncoder(); % Create an object handling Aksim diagnostic for exp. A
-my_aksim_encoder_B = AksimEncoder(); % Create an object handling Aksim diagnostic for exp. B
 
-my_amo_encoder = AmoEncoder(); % Create an object handling Amo diagnostic
+% my_amo_encoder = AmoEncoder(); % Create an object handling Amo diagnostic
 %% Display result:
 my_aksim_encoder_A.computeDiagnosticError(my_experiment_A); % Compute diagnostic for experiment A
 my_aksim_encoder_A.displayReport(); % Display diagnostic result for experiment A
 fprintf('\n \n'); % Displays empty line between diagnostic display
-my_aksim_encoder_B.computeDiagnosticError(my_experiment_B); % Compute diagnostic for experiment B
-my_aksim_encoder_B.displayReport(); % Display diagnostic result for experiment B
+
 %% Plot data:
 % If you have different experiments you need to declare an empty figure per
 % plot. If you don't do this matlab will overwrite the previous plot.
-
 figure(1)
 my_aksim_encoder_A.plotDiagnosticOnRawData(my_experiment_A); % Plot experiment A diagnostic on raw values
-
-figure(2)
-my_aksim_encoder_B.plotDiagnosticOnRawData(my_experiment_B); % Plot experiment B diagnostic on raw values


### PR DESCRIPTION
It is now possible to define the portion of the experiment to analyze by specifying a start time and/or end time.

The following features are supported:
* Defining "StartTime" the experiment is trimmed from this time onward.
* Defining "EndTime" the experiment is trimmed up to this time.
* Defining "StartTime" and "EndTime" the experiment is trimmed in a specific window.

The code handles the following cases:
* EndTime < StartTime: This results in an empty experiment.
*  StartTime <0 and/or EndTime < 0: If either value is negative, a warning is issued, the corresponding time is ignored, and the default (start or end of the experiment) is used.