### PR TITLE
Adding GitHub actions workflow for CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,50 @@
+# This is a basic workflow to help you get started with Actions
+
+name: CI
+
+# Controls when the workflow will run
+on:
+  # Triggers the workflow on push or pull request events but only for the "master" branch
+  push:
+    branches: [ "code" ]
+  pull_request:
+    branches: [ "code" ]
+  workflow_dispatch: {}
+
+jobs:
+  test:
+    name: Run MATLAB tests
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+      # Set up MATLAB and other MathWorks products on the runner.
+      - name: Set up MATLAB
+        uses: matlab-actions/setup-matlab@v2
+        with:
+          release: latest
+          cache: true
+          # Set up additional products using the products input.
+          # See https://github.com/matlab-actions/setup-matlab/#set-up-matlab
+          # products: Simulink Deep_Learning_Toolbox
+
+      # Run tests authored using the MATLAB unit testing framework or Simulink Test.
+      - name: Run MATLAB tests
+        uses: matlab-actions/run-tests@v2
+        # If you are not using a MATLAB project, add your source code to the path using the source-folder input.
+        with:
+          test-results-junit: test-results/results.xml
+          code-coverage-cobertura: code-coverage/coverage.xml
+          source-folder: MultiJoint_Setup_Analysis_Script
+
+      - name: TestForest Dashboard
+        # You may pin to the exact commit or the version.
+        # uses: test-summary/action@032c8a9cec6aaa3c20228112cae6ca10a3b29336
+        uses: test-summary/action@v2.3
+        with:
+          # Path(s) to test output file(s) to analyze
+          paths: test-results/results.xml


### PR DESCRIPTION
This PR adds the GitHub actions workflow for CI.

Its purpose is to establish a continuous integration pipeline that runs tests:
- on every push to the `code` branch  
- whenever a pull request is opened

Currently, only the tests included in the `MultiJoint_Setup_Analysis_Script` are executed.  
Other scripts are **not** covered by this CI pipeline at this stage.

---

Closes #59